### PR TITLE
Set up spot size decrease

### DIFF
--- a/macros/Util-ZBTutorialShared.py
+++ b/macros/Util-ZBTutorialShared.py
@@ -21,7 +21,7 @@ NewSpecimenSteps:list[Step] = [
     DoAutomatically(lambda: SetMagIndex(LowMag150)),
     TellOperatorTEM("Remove the aperture by turning the dial to the red dot."),
     DoAutomatically(TurnOnFilament),
-    DoAutomatically(lambda: SetSpotSize(2)),
+    DependingOnScope(DoAutomatically(lambda: SetSpotSize(3)),DoAutomatically(lambda: SetSpotSize(2))),
     DoAutomatically(ScreenDown),
     TellOperatorSEM("Scroll the stage to find a region of formvar, and click 'Add Stage Pos' in the navigator window."),
 ]
@@ -72,7 +72,7 @@ def SwitchToHighMagSteps(recap:bool, investigator:str, volume:str, Mag:int, MagI
         DoAutomatically(Record)
     ] + ([
         OpenLastSnapshot(recap, investigator, volume, Mag),
-        TellOperatorSEM(f"Find the center point at {Mag}x, and click it. Then click 'Add Marker'. If another navigator item is visible, delete it."),
+        TellOperatorSEM(f"Find the center point at {Mag}x, and use 'Move Item' to relocate the centerpoint marker to the correct location."),
         DoAutomatically(lambda: MoveToNavItem()),
         DoAutomatically(Record),
         ManuallyCheckCenterPoint,

--- a/macros/Util-ZZTutorialCore.py
+++ b/macros/Util-ZZTutorialCore.py
@@ -14,7 +14,7 @@ def MainCoreSteps(detailed:bool, recap:bool) ->list[Step]:
         TellOperatorSEM("In the menubar, click Navigator -> Montaging and Grids -> Polygon from Corners. Zoom out to make sure the generated polygon is your intended shape, then delete the corner points."),
         TellOperatorSEM(f"With the polygon selected, check the Navigator checkboxes for 'Aquire', 'New File At Item', 'Montaged Images', 'Fit Montage to Polygon'. {newline} {newline} In setup window: {newline} Make sure overlap is set to 15% {newline} 'Go from center out and anchor at 2000x' is NOT checked {newline} click ok. Then select the generated idoc file. Choose to overwrite it."),
         DoAutomatically(lambda: MoveToNavItem(PolygonIndex)),
-        DoAutomatically(lambda: SetSpotSize(1)),
+        DoAutomatically(lambda: SetSpotSize(2)),
         DoAutomatically(ScreenDown)
     ] + FocusSteps + FinalSteps(detailed, True, recap)
 

--- a/macros/Util-ZZTutorialCore.py
+++ b/macros/Util-ZZTutorialCore.py
@@ -7,13 +7,14 @@ def MainCoreSteps(detailed:bool, recap:bool) ->list[Step]:
         TellOperatorSEM("Locate the Region of Interest at 150x (you may need to move the stage). Click 'Add Points' in the navigator window and click on the corners of the ROI. Then click 'Stop Adding Points'."),
         TellOperatorSEM("Select each of the corner points and type 'C' on the keyboard to mark them as corner points."),
         DoAutomatically(lambda: TakeSnapshotWithNotes("corners", False))
-    ] + SwitchToHighMagSteps(recap, "", "", 2000, HighMag2000, 1, True, False, []) + [
+    ] + SwitchToHighMagSteps(recap, "", "", 2000, HighMag2000, 2, True, False, []) + [
         DoAutomatically(lambda: SetMagIndex(HighMag5000))
     ] + FocusSteps + [
         TellOperatorSEM("For each corner point, click 'Go to XY' and take a recording. If the point is not where you expect it to be, zoom out with the scrollbar to see its position relative to the other corners, then zoom back in and use 'Search' to find its real position. Then use 'Move item' to move the point."),
         TellOperatorSEM("In the menubar, click Navigator -> Montaging and Grids -> Polygon from Corners. Zoom out to make sure the generated polygon is your intended shape, then delete the corner points."),
         TellOperatorSEM(f"With the polygon selected, check the Navigator checkboxes for 'Aquire', 'New File At Item', 'Montaged Images', 'Fit Montage to Polygon'. {newline} {newline} In setup window: {newline} Make sure overlap is set to 15% {newline} 'Go from center out and anchor at 2000x' is NOT checked {newline} click ok. Then select the generated idoc file. Choose to overwrite it."),
         DoAutomatically(lambda: MoveToNavItem(PolygonIndex)),
+        DoAutomatically(lambda: SetSpotSize(1)),
         DoAutomatically(ScreenDown)
     ] + FocusSteps + FinalSteps(detailed, True, recap)
 

--- a/macros/Util-ZZTutorialVolume.py
+++ b/macros/Util-ZZTutorialVolume.py
@@ -16,7 +16,7 @@ def MainVolumeSteps(investigator:str, name:str, radius:int, detailed:bool, recap
         DoAutomatically(lambda: SetMagIndex(HighMag5000)),
         TellOperatorSEM(f"With the circle polygon selected, check the Navigator checkboxes for 'Aquire', 'New File At Item', 'Montaged Images', 'Fit Montage to Polygon'. {newline} {newline} In setup window: {newline} Make sure overlap is set to 12% {newline} 'Go from center out and anchor at 2000x' is active {newline} click ok. Then select the generated idoc file. Choose to overwrite it."),
         DoAutomatically(lambda: MoveToNavItem(PolygonIndex)),
-        DoAutomatically(lambda: SetSpotSize(1)),
+        DoAutomatically(lambda: SetSpotSize(2)),
         DoAutomatically(ScreenDown)
     ] + FocusSteps + FinalSteps(detailed, False, recap)
 

--- a/macros/Util-ZZTutorialVolume.py
+++ b/macros/Util-ZZTutorialVolume.py
@@ -5,17 +5,18 @@ def MainVolumeSteps(investigator:str, name:str, radius:int, detailed:bool, recap
     
     return [
         OpenLastSnapshot(recap, investigator, name, 150),
-        TellOperatorSEM("Locate the center point at 150x, click it, and click 'Add Marker' in the navigator window."),
+        TellOperatorSEM(f"Locate the center point at 150x, click it, and click 'Add Marker' in the navigator window.{newline} {newline} If no image appears or image is washed out, check current density and press 'Record' to have image for placing new centerpoint"),
         DoAutomatically(lambda: MoveToNavItem(PolygonIndex)),
         DoAutomatically(Record),
         ManuallyCheckCenterPoint,
         DoAutomatically(lambda: TakeSnapshotWithNotes("", False))
-    ] + SwitchToHighMagSteps(recap, investigator, name, 600, HighMag600, SpotSize2, True, True, []) + SwitchToHighMagSteps(recap, investigator, name, 2000, HighMag2000, SpotSize1, False, True, FocusSteps) + [
+    ] + SwitchToHighMagSteps(recap, investigator, name, 600, HighMag600, SpotSize3, True, True, []) + SwitchToHighMagSteps(recap, investigator, name, 2000, HighMag2000, SpotSize2, False, True, FocusSteps) + [
         TellOperatorSEM(f"In the menubar, click Navigator -> Montaging and Grids -> Add Circle Polygon. Type {radius}"),
         TellOperatorSEM("In the navigator window, delete every item EXCEPT FOR the formvar reference point and the circle Polygon."),
         DoAutomatically(lambda: SetMagIndex(HighMag5000)),
         TellOperatorSEM(f"With the circle polygon selected, check the Navigator checkboxes for 'Aquire', 'New File At Item', 'Montaged Images', 'Fit Montage to Polygon'. {newline} {newline} In setup window: {newline} Make sure overlap is set to 12% {newline} 'Go from center out and anchor at 2000x' is active {newline} click ok. Then select the generated idoc file. Choose to overwrite it."),
         DoAutomatically(lambda: MoveToNavItem(PolygonIndex)),
+        DoAutomatically(lambda: SetSpotSize(1)),
         DoAutomatically(ScreenDown)
     ] + FocusSteps + FinalSteps(detailed, False, recap)
 


### PR DESCRIPTION
Decreased spot size during setup to avoid burns in the sample. Updated setup instructions to move item instead of adding/deleting markers. 